### PR TITLE
Added option to import sub list, resolved issue with linking fsaverage

### DIFF
--- a/4-reconall/recon-all_parallel_aux.sh
+++ b/4-reconall/recon-all_parallel_aux.sh
@@ -27,9 +27,10 @@ fi
 if [ -e "$SUBJECTS_DIR/$subdir" ]; then
     echo "$subject_id is already processed. Skipping..."
 elif [ -e "$BIDS_FOLDER/$subsesbids/anat/${subdir}_run-01_T2w.nii.gz" ]; then
+
     # Run FreeSurfer recon-all command
-    recon-all -all -s "$subject_id" -T2 "$BIDS_FOLDER/$subsesbids/anat/${subdir}_run-01_T2w.nii.gz" -T2pial -i "$BIDS_FOLDER/$subsesbids/anat/${subdir}_run-01_T1w.nii.gz" -3T -openmp "$PCORES"
-    
+    recon-all -all -sd "$SUBJECTS_DIR" -s "$subject_id" -T2 "$BIDS_FOLDER/$subsesbids/anat/${subdir}_run-01_T2w.nii.gz" -T2pial -i "$BIDS_FOLDER/$subsesbids/anat/${subdir}_run-01_T1w.nii.gz" -3T -openmp "$PCORES"
+
     # Check for errors
     if [ $? -ne 0 ]; then
         echo "Error processing $subject_id. Check FreeSurfer logs for details."


### PR DESCRIPTION
- [ ] Updated so you can either input a list of subjects to process or have the list generated automatically
- [ ] Exported and added SUBJECTS_DIR in both the launcher and the SBATCH job (--export=ALL,...) and passed it to recon-all via -sd.
- [ ] Added a symlink ("$SUBJECTS_DIR/fsaverage" points to "$FREESURFER_HOME/subjects/fsaverage”) to resolve the issue with the fsaverage directory pointing to an outdated version of FreeSurfer